### PR TITLE
Add code to disable colour generation if focus is on inputs

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -11,7 +11,7 @@ const generateColourPalette = () => {
 }
 
 const generateNewColourPalette = (e) => {
-  e.keyCode === 32 ? generateColourPalette() : false
+  e.keyCode === 32 && !$('input').is(':focus') ? generateColourPalette() : false
 }
 
 const displayLock = (e) => {


### PR DESCRIPTION
If focus is placed in either input, pressing spacebar will not cause colour palettes to re-generate.